### PR TITLE
Adds "hole" and "outer" contour pixels as optional columns to DataFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A Julia package containing a number of algorithms for analyzing connected components
 in binary images. In general, the input is an array of labelled components, and the output
 is a [DataFrame](https://github.com/JuliaData/DataFrames.jl) where each row
-represents a connected components, and each column represents an attribute of
+represents a connected component, and each column represents an attribute of
 that connected component. When combined with [Query](https://github.com/queryverse/Query.jl)
 it affords a very flexible and easy way of filtering connected components
 based on their attributes.

--- a/src/ImageComponentAnalysis.jl
+++ b/src/ImageComponentAnalysis.jl
@@ -15,10 +15,6 @@ using PlanarConvexHulls
 using StaticArrays: SVector, MVector
 
 
-
-
-
-
 # TODO: port ComponentAnalysisAPI to ImagesAPI
 include("ComponentAnalysisAPI/ComponentAnalysisAPI.jl")
 import .ComponentAnalysisAPI: AbstractComponentAnalysisAlgorithm,
@@ -40,6 +36,7 @@ export
     BasicMeasurement,
     BasicTopology,
     BoundingBox,
+    Contour,
     #ContourTopology, TODO
     MinimumOrientedBoundingBox,
     establish_contour_hierarchy,

--- a/src/algorithms/basic_measurement.jl
+++ b/src/algorithms/basic_measurement.jl
@@ -2,7 +2,7 @@
 ```
     BasicMeasurement <: AbstractComponentAnalysisAlgorithm
     BasicMeasurement(; area = true,  perimeter = true)
-    analyze_components(components, f::BasicMeasuremen)
+    analyze_components(components, f::BasicMeasurement)
     analyze_components!(dataframe::AbstractDataFrame, components, f::BasicMeasurement)
 ```
 Takes as input an array of labelled connected components and returns a

--- a/src/algorithms/minimum_oriented_bounding_box.jl
+++ b/src/algorithms/minimum_oriented_bounding_box.jl
@@ -8,7 +8,7 @@
 Takes as input an array of labelled connected components and returns a
 `DataFrame` with columns that store a length-4 vector containing the four corner
 points of the minimum oriented bounding box of each component. It optionally
-also returns the area and aspect ration of the minimum oriented bounding box.
+also returns the area and aspect ratio of the minimum oriented bounding box.
 
 # Example
 

--- a/test/contour_topology.jl
+++ b/test/contour_topology.jl
@@ -50,10 +50,80 @@
                          CartesianIndex(4, 18), CartesianIndex(3, 18), CartesianIndex(2, 18), CartesianIndex(2, 17),
                          CartesianIndex(2, 16), CartesianIndex(2, 15), CartesianIndex(2, 14), CartesianIndex(2, 13)],
                          []]
+    # Verify the veracity of the contour hierarchy and contour pixels.
     for (k,i) in enumerate(PostOrderDFS(tree))
         @test i.data.id == expected_id[k]
         if k != 9
             @test all(i.data.pixels .== expected_pixels[k])
         end
     end
+
+    # Verify the veracity of the data frame that stores the contour pixels.
+    outer_contour_1 = [  CartesianIndex(2, 2),
+                         CartesianIndex(3, 2),
+                         CartesianIndex(4, 2),
+                         CartesianIndex(5, 2),
+                         CartesianIndex(6, 2),
+                         CartesianIndex(7, 2),
+                         CartesianIndex(8, 2),
+                         CartesianIndex(8, 3),
+                         CartesianIndex(8, 4),
+                         CartesianIndex(8, 5),
+                         CartesianIndex(8, 6),
+                         CartesianIndex(8, 7),
+                         CartesianIndex(8, 8),
+                         CartesianIndex(7, 8),
+                         CartesianIndex(6, 8),
+                         CartesianIndex(5, 8),
+                         CartesianIndex(4, 8),
+                         CartesianIndex(3, 8),
+                         CartesianIndex(2, 8),
+                         CartesianIndex(2, 7),
+                         CartesianIndex(2, 6),
+                         CartesianIndex(2, 5),
+                         CartesianIndex(2, 4),
+                         CartesianIndex(2, 3)  ]
+
+    hole_contour_1 =  [   CartesianIndex(3, 2),
+                          CartesianIndex(2, 3),
+                          CartesianIndex(2, 4),
+                          CartesianIndex(2, 5),
+                          CartesianIndex(2, 6),
+                          CartesianIndex(2, 7),
+                          CartesianIndex(3, 8),
+                          CartesianIndex(4, 8),
+                          CartesianIndex(5, 8),
+                          CartesianIndex(6, 8),
+                          CartesianIndex(7, 8),
+                          CartesianIndex(8, 7),
+                          CartesianIndex(8, 6),
+                          CartesianIndex(8, 5),
+                          CartesianIndex(8, 4),
+                          CartesianIndex(8, 3),
+                          CartesianIndex(7, 2),
+                          CartesianIndex(6, 2),
+                          CartesianIndex(5, 2),
+                          CartesianIndex(4, 2)  ]
+
+    outer_contour_2 = [   CartesianIndex(4, 4),
+                          CartesianIndex(5, 4),
+                          CartesianIndex(6, 4),
+                          CartesianIndex(6, 5),
+                          CartesianIndex(6, 6),
+                          CartesianIndex(5, 6),
+                          CartesianIndex(4, 6),
+                          CartesianIndex(4, 5)  ]
+
+    hole_contour_2 =  [   CartesianIndex(5, 4),
+                          CartesianIndex(4, 5),
+                          CartesianIndex(5, 6),
+                          CartesianIndex(6, 5)   ]
+
+    component_labels = ImageComponentAnalysis.label_components(img1, trues(3,3))
+    measurements = analyze_components(component_labels, Contour())
+
+    @test all(measurements[1,:].outer_contour .== outer_contour_1)
+    @test all(measurements[1,:].hole_contour .== hole_contour_1)
+    @test all(measurements[2,:].outer_contour .== outer_contour_2)
+    @test all(measurements[2,:].hole_contour .== hole_contour_2)
 end


### PR DESCRIPTION
The "outer" and "hole" contour pixels that are traced by the Suzuki contour tracing algorithm can now be placed into the `DataFrame` associated with `analyze_components`.

Also fixes a few small typos in docstrings.