### PR TITLE
Replaces PlanarConvexHulls dependency with ConvexHulls2d

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "ImageComponentAnalysis"
 uuid = "d9b9e9a0-1569-11e9-2cb5-bbca914b0e89"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+ConvexHulls2d = "438b5665-92b0-42e6-bc36-e4ac8449fa2d"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
@@ -12,18 +13,17 @@ LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-PlanarConvexHulls = "145d500b-351c-58b3-a0aa-f5d7e249d989"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 AbstractTrees = "0.3, 0.4"
+ConvexHulls2d = "0.1.1"
 DataFrames = "0.19.4, 0.20, 1.2"
 DataStructures = "0.17.3, 0.17, 0.18"
 ImageFiltering = "0.6.5, 0.6, 0.7"
 LeftChildRightSiblingTrees = "0.1, 0.2"
 OffsetArrays = "0.11.3, 1, 1.10"
 Parameters = "0.12.0"
-PlanarConvexHulls = "0.3"
 StaticArrays = "0.11.1, 0.12, 1"
 julia = "1.1.0, 1"
 

--- a/src/ImageComponentAnalysis.jl
+++ b/src/ImageComponentAnalysis.jl
@@ -10,7 +10,7 @@ using LeftChildRightSiblingTrees
 using LinearAlgebra
 using OffsetArrays: OffsetVector
 using Parameters
-using PlanarConvexHulls
+using ConvexHulls2d
 using StaticArrays
 
 

--- a/src/algorithms/minimum_oriented_bounding_box.jl
+++ b/src/algorithms/minimum_oriented_bounding_box.jl
@@ -69,11 +69,11 @@ end
 
 function determine_minimum_rectangle(points₀::AbstractArray)
     # Determine the convex hull for the specified set of points.
-    points = map(x-> SVector(x.I), points₀)
-    chull = ConvexHull{CW, Float64}()
-    jarvis_march!(chull, points)
-    N = num_vertices(chull)
-    vert = vertices(chull)
+    points = map(x-> SVector(x.I), points₀) 
+    hull = ConvexHulls2d.ConvexHull(points)
+    vert = ConvexHulls2d.vertices(hull)
+    N = length(vert)
+
     if N == 1
         # When there is only a single vertex there is no unique minimum bounding
         # retangle. In this instance we mark the four corners of the bounding

--- a/test/minimum_oriented_bounding_box.jl
+++ b/test/minimum_oriented_bounding_box.jl
@@ -1,5 +1,5 @@
 @testset "minimum oriented bounding box" begin
-    expected_vertices = [SVector(30.0, 50.0), SVector(30.0, 100.0), SVector(60.0, 100.0), SVector(60.0, 50.0)]
+    expected_vertices = [SVector(30.0, 100.0), SVector(60.0, 100.0), SVector(60.0, 50.0), SVector(30.0, 50.0)]
     expected_area = 1500.0
     expected_aspect_ratio = 50/30
     img = zeros(Gray{Float64},(200,200))


### PR DESCRIPTION
Note that while ConvexHulls2d returns the vertices in the same orientation as PlanarConvexHulls, the starting vertex is not necessarily the same.